### PR TITLE
Remove the inactive administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ The admin of the Hackathon Hackers group exists solely to oversee the moderation
 - Modifying the sidebar
 - Adding a newly appointed admin
 
-There is only one active admin, though the creator of the group exists on the panel, only to ensure that no newly added admin ever reaches a point where they refuse to give up ownership of the group when their term has ended.
+There is only one active admin.
 
-The Subgroup Leaders have the power to call for a new election to take place, and the admin can choose whether or not to participate. The admin can retain their position either until they choose to reliquish it, or a new admin has been elected. The inactive admin has no authority over the active admin, nor the group as a whole, unless explicitly called upon by the Subgroup Leaders to transition power from the current admin to the newly elected admin.
+The Subgroup Leaders have the power to call for a new election to take place, and the admin can choose whether or not to participate. The admin can retain their position either until they assign an interim administrator, or a new admin has been elected. The (interim) admin is expected to add the winner of the election as an administrator and remove themselves within 24 hours of it concluding.
 
 Subgroup Leadership
 ----


### PR DESCRIPTION
The inactive administrator is an unnecessary position which will only result in this plan being opposed by the community. This PR removes the inactive administrator and adds a definite time period between the election concluding and the new (only) administrator being added. If the administrator does not replace themselves within 24 hours, we can consider the community to have been taken over.

Of course, a takeover would never happen. The plan would be doomed from the start, as takeovers are very obvious (the admin list is always public) and censorship of posts would only delay the group's eventual demise. Additionally, groups are not a finite resource, and a new group would be up and running hours after the admin was supposed to replace themselves. Since the admin who wants to take over the group obviously wants the group to be active, such a plan is useless.

This PR resolves #4. Open to rewording the changes.
